### PR TITLE
calendrier et annee differente

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -13,6 +13,10 @@ class EventsController < ApplicationController
     else
       @date = Date.today
     end
+
+    @year = Date.today.year
+
+    @events = @events.where(starts_at: @date.beginning_of_month..@date.end_of_month)
   end
 
   def show

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -6,7 +6,7 @@
     <%= link_to events_path(date: @date - 1.month, category: params[:category]) do  %>
       <h5> <small> <i class="fa-solid fa-arrow-left-long"></i> </small> <%= l((@date - 1.month), format: "%b").capitalize %></h5>
     <% end %>
-    <h3><strong><%= l((@date), format: "%^B") %></strong></h3>
+    <h3><strong><%= l(@date, format: "%^B") %></strong> <small><%= if @date.year != @year then l(@date, format: "%y") end %></small></h3>
     <%= link_to events_path(date: @date + 1.month, category: params[:category]) do %>
       <h5><%= l((@date + 1.month), format: "%b").capitalize %> <small> <i class="fa-solid fa-arrow-right"></i> </small></h5>
     <% end  %>


### PR DESCRIPTION
correction d'affichage du calendrier pour afficher que les évènements du mois de l'année en cours (et non pas de toutes les années simultanément)
affichage de l'année sur le calendrier que si l'année affichée est différente de l'année en cours